### PR TITLE
[ICC-30] 레디스 도커 컴포즈 작성 완료

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  q-asker-redis:
+    image: redis:latest
+    container_name: q-asker-redis
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+    expose:
+      - "6379"
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:


### PR DESCRIPTION
## 📢 설명
fastAPI에서 프롬프트를 임시 저장 하기위해 그리고 그것을 람다가 꺼내기 위해 +
람다가 bedrock으로부터의 응답을 받으면 임시 저장하기 위해 그리고 그것을 fastAPI에서 꺼내기 위해 +
fastAPI가 redis의 특정 key를 구독하고있다가 그 key를 통해 메시지가 오면 모든 요청이 생성되었는지 확인하기 위한 기능을 구현하기 위해 redis를 사용하고자합니다
따라서 docker-compose를 작성하였습니다

## ✅ 체크 리스트
- [x] .env 업데이트
- [x] 노션 - 테스트 - ai서버 - 원격 서버 redis와의 연결 참고하여 구성
- [x] 코드 리뷰
