### PR TITLE
[ICC-53] 구현 완료

### DIFF
--- a/app/service/generate_service.py
+++ b/app/service/generate_service.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 from langchain_core.output_parsers import JsonOutputParser
 
@@ -24,16 +25,27 @@ class GenerateService:
         bedrock_contents = []
         full_text = process_file(uploaded_url)
         summary = await create_summary(full_text)
-        chunks = await create_chunks(full_text, quiz_count)
 
-        for chunk in chunks:
+        quiz_count_per_chunk = 5
+        if quiz_count % quiz_count_per_chunk == 0:
+            quiz_count_last_chunk = quiz_count_per_chunk
+        else:
+            quiz_count_last_chunk = quiz_count % quiz_count_per_chunk
+
+        chunks = await create_chunks(full_text, quiz_count, quiz_count_per_chunk)
+
+        for i, chunk in enumerate(chunks, start=1):
+            if len(chunks) != i:
+                cur_quiz_count_per_chunk = quiz_count_per_chunk
+            else:
+                cur_quiz_count_per_chunk = quiz_count_last_chunk
             bedrock_contents.append(
                 {
                     "modelId": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
                     "body": {
                         "anthropic_version": "bedrock-2023-05-31",
                         "max_tokens": 20000,
-                        "system": "당신은 교육 전문 AI 조교입니다. 요약과 함께 제공된 강의노트를 분석하여 학생들의 이해도를 평가할 수 있는 효과적인 퀴즈를 5개 생성해주세요. JSON 이외의 텍스트는 절대 출력하지 마세요.",
+                        "system": f"당신은 교육 전문 AI 조교입니다. 요약과 함께 제공된 강의노트를 분석하여 학생들의 이해도를 평가할 수 있는 효과적인 퀴즈를 {cur_quiz_count_per_chunk}개 생성해주세요. JSON 이외의 텍스트는 절대 출력하지 마세요.",
                         "messages": [
                             {
                                 "role": "user",
@@ -49,16 +61,22 @@ class GenerateService:
 
                                             # 강의노트
                                             {chunk}
-                                        """
+                                        """,
                                     }
-                                ]
+                                ],
                             }
-                        ]
-                    }
+                        ],
+                    },
                 }
-            ) 
+            )
 
+        start = time.time()
         responses = await request_to_bedrock(bedrock_contents)
+        end = time.time()
+        elapsed = end - start
+        print(
+            f"청크 당 퀴즈 카운트 {quiz_count_per_chunk}개 일 때 소요 시간: {elapsed:.4f}초"
+        )
 
         all_quizzes = []
         for response in responses:

--- a/app/util/create_chunks.py
+++ b/app/util/create_chunks.py
@@ -1,7 +1,10 @@
-async def create_chunks(text: str, quiz_count: int):
+import math
+
+
+async def create_chunks(text: str, quiz_count: int, quiz_count_per_chunk: int) -> list:
     try:
         chunks = []
-        chunk_count = quiz_count // 5
+        chunk_count = math.ceil(quiz_count / quiz_count_per_chunk)
         chunk_size = len(text) // chunk_count
         for i in range(chunk_count):
             start = i * chunk_size


### PR DESCRIPTION
## 📢 설명
### 로직
quiz_count_per_chunk변수로 청크당 퀴즈 개수를 유연하게 조정하고자합니다
나누어 떨어지지 않을 때는 청크가 하나 덜 만들어지므로
```chunk_count = math.ceil(quiz_count / quiz_count_per_chunk)```로 수정합니다

나누어 떨어질 때는 quiz_count % quiz_count_per_chunk가 0이므로
대신 ```quiz_count_last_chunk = quiz_count_per_chunk```로 둡니다

마지막 청크에 대해서만 quiz_count_last_chunk로 퀴즈 개수를 만들어달라고합니다

### 타이머
```await request_to_bedrock(bedrock_contents)```의 수행시간을 로깅합니다
예시: ```청크 당 퀴즈 카운트 5개 일 때 소요 시간: 27.2863초```

## ✅ 체크 리스트
- [ ] quiz_count_per_chunk값을 다양하게 조절해보며 테스트
- [ ] 코드 리뷰
