### PR TITLE
[ICC-67] 응답 구조 수정

### DIFF
--- a/app/dto/model/problem_set.py
+++ b/app/dto/model/problem_set.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class Selection(BaseModel):
+    content: str = Field(description="선택지 내용입니다.")
+    correct: bool = Field(
+        description="정답 여부입니다. 정답이면 True, 오답이면 False입니다."
+    )
+
+
+class Problem(BaseModel):
+    number: int = Field(description="문제 번호입니다.")
+    title: str = Field(description="문제 내용입니다.")
+    selections: List[Selection] = Field(description="선택지 목록입니다.")
+    explanation: str = Field(description="문제에 대한 해설입니다.")
+
+
+class ProblemSet(BaseModel):
+    quiz: List[Problem] = Field(description="퀴즈 목록입니다.")

--- a/app/dto/response/generate_response.py
+++ b/app/dto/response/generate_response.py
@@ -1,16 +1,17 @@
-from pydantic import BaseModel, Field
 from typing import List
 
+from pydantic import BaseModel
 
-class Selection(BaseModel):
-    content: str = Field(description="선택지 내용입니다.")
-    correct: bool = Field(description="정답 여부입니다. 정답이면 True, 오답이면 False입니다.")
+from app.dto.model.problem_set import Selection
 
-class Problem(BaseModel):
-    number: int = Field(description="문제 번호입니다.")
-    title: str = Field(description="문제 내용입니다.")
-    selections: List[Selection] = Field(description="선택지 목록입니다.")
-    explanation: str = Field(description="문제에 대한 해설입니다.")
+
+class ProblemResponse(BaseModel):
+    number: int
+    title: str
+    selections: List[Selection]
+    explanation: str
+    referencedPages: List[int]
+
 
 class GenerateResponse(BaseModel):
-    quiz: List[Problem] = Field(description="퀴즈 목록입니다.")
+    quiz: List[ProblemResponse]

--- a/app/util/create_chunks.py
+++ b/app/util/create_chunks.py
@@ -60,7 +60,7 @@ def compress_chunks(max_chunk_count: int, chunks: List[ChunkInfo]) -> List[Chunk
             idx += 1
             merged_chunk.quiz_count += chunk.quiz_count
 
-        merged_chunk.referenced_pages = list(index_set)
+        merged_chunk.referenced_pages = list(sorted(index_set))
         compressed_chunks.append(merged_chunk)
 
     return compressed_chunks
@@ -135,13 +135,11 @@ def handle_quiz_larger_than_total_page(
     quiz_counts = [0] * (page_count + 1)
 
     for k in range(total_quiz_count):
-        # floor(k * (P/Q)) + 1 을 1-based 페이지 번호로 사용
         page_idx = math.floor(k * page_per_quiz) + 1
         if page_idx > page_count:
             page_idx = page_count
         quiz_counts[page_idx] += 1
 
-    # 이제 i = 1 ~ P 에 대해 ChunkInfo 생성
     for i in range(1, page_count + 1):
         chunk_info = ChunkInfo(
             text=pages[i],


### PR DESCRIPTION
## 📢 설명
1. 응답 DTO용 클래스 만듦, parser에 넣는 그것과 역할 분리
2. 프롬프트 가독성 좋게 변경
3. 페이지를 참조해야하므로 만들어진 문제들을 sequence 기준 오름차순 정렬, 페이지 참조 정보는 청크 순서대로 존재하기 때문입니다
    - sequence는 레디스 퍼블리시 메시지에서 오는 몇번째 청크에서 퀴즈가 만들어졌는지를 알려주는 정보입니다
![image](https://github.com/user-attachments/assets/7afb70bb-a5b0-4164-a34f-271ff63e452b)
4. 상세 설명: 댓글에 존재

## ✅ 체크 리스트
- [x] API 테스트하여 아래와 같이 응답이 오는지 확인(노션 - 테스트 - AI 서버 - 문제 생성 테스트 요청 구조로 간단하게 테스트 가능)
```
{
  "quiz": [
    {
      "number": 1,
      "title": "JTextField에 대한 설명으로 올바르지 않은 것은?",
      "selections": [
        {
          "content": "여러 줄의 텍스트를 입력할 수 있는 컴포넌트이다.",
          "correct": true
        },
        {
          "content": "텍스트 입력 중 Enter키를 누르면 Action 이벤트가 발생한다.",
          "correct": false
        },
        {
          "content": "입력 가능한 문자 개수와 입력 창의 크기는 서로 다를 수 있다.",
          "correct": false
        },
        {
          "content": "한 줄 짜리 문자열 입력이 가능한 컴포넌트이다.",
          "correct": false
        }
      ],
      "explanation": "JTextField는 한 줄 짜리 텍스트만 입력할 수 있는 컴포넌트입니다. 여러 줄의 텍스트를 입력하기 위해서는 JTextArea를 사용해야 합니다.",
      "referencedPages": [
        1,
        2,
        3
      ]
    },
    ...
```
- [x] 코드 리뷰
